### PR TITLE
setup: avoid `-march=native`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     ext_modules=[
         Extension("intbitset",
                   ["src/intbitset.c", "src/intbitset_impl.c"],
-                  extra_compile_args=['-O3', '-march=native']
+                  extra_compile_args=['-O3', '-march=core2', '-mtune=native']
                   # For debug -> '-ftree-vectorizer-verbose=2'
                   )
     ],


### PR DESCRIPTION
* Stops using `-march=native` for compilation, because it makes the
  compiler to optimize the code for only the currently used processor.
  That includes the usage of special instructions sets. Therefore the
  resulting binaries are not usable by other systems in the same server
  farm. (results in `illegal instruction` crashes) A workaround would
  be to install a compiler on each system what is a very strong
  assumption for production system.

Signed-off-by: Marco Neumann <marco@crepererum.net>