### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,9 +1,9 @@
 Authors
 -------
 
-IntbitSet is developed for use in `Invenio <http://invenio-software.org>`_ digital library software.
+IntbitSet is developed for use in `Invenio <http://inveniosoftware.org>`_ digital library software.
 
-Contact us at `info@invenio-software.org <mailto:info@invenio-software.org>`_
+Contact us at `info@inveniosoftware.org <mailto:info@inveniosoftware.org>`_
 
 Contributors
 ^^^^^^^^^^^^

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -32,8 +32,8 @@ Documentation
 Happy hacking and thanks for flying intbitset.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/intbitset
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,4 +1,4 @@
 Contributing
 ============
 
-See <http://invenio-software.org/wiki/Development/Contributing> for now.
+See <http://inveniosoftware.org/wiki/Development/Contributing> for now.

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     url='http://github.com/inveniosoftware/intbitset/',
     license='LGPLv3+',
     author='Invenio collaboration',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     description=__doc__,
     long_description=open('README.rst').read(),
     package_dir={'': 'intbitset'},


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>